### PR TITLE
Troca display none por visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Moodify é uma página web simples que detecta e exibe seu humor.
 2. Acesse `http://localhost:8000/index.html` (ou outro endereço seguro/HTTPS) no navegador.
 3. Permita o acesso à câmera quando solicitado.
 4. Clique em **Detectar Meu Humor** para que a aplicação analise sua expressão facial.
+5. O vídeo usado para análise fica oculto na página.
 
 O sistema utiliza a biblioteca [face-api.js](https://github.com/justadudewhohacks/face-api.js) para detectar emoções e ajusta a página conforme o resultado.
 

--- a/index.html
+++ b/index.html
@@ -42,11 +42,15 @@
     button:hover {
       background-color: #ff1493;
     }
+
+    #video {
+      visibility: hidden;
+    }
   </style>
 </head>
 <body>
   <h1>🎵 Moodify</h1>
-  <video id="video" width="320" height="240" autoplay muted style="display:none"></video>
+  <video id="video" width="320" height="240" autoplay muted></video>
   <div id="emoji">😊</div>
   <div id="moodText">Seu humor atual: Feliz</div>
   <button onclick="detectMood()">Detectar Meu Humor</button>


### PR DESCRIPTION
## Summary
- hide the `<video>` element using `visibility: hidden`
- note in docs that the camera video remains hidden

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ed2ff94c833194731b46afb562ef