### PR TITLE
Implement on-page log output

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,23 @@
     #video {
       visibility: hidden;
     }
+
+    #logOutput {
+      font-family: monospace;
+      background-color: #f9f9f9;
+      border: 1px solid #ddd;
+      padding: 10px;
+      border-radius: 5px;
+      color: #000;
+      font-size: 14px;
+      max-height: 200px;
+      overflow-y: auto;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      margin-top: 30px;
+    }
   </style>
 </head>
 <body>
@@ -57,6 +74,25 @@
 
   <script src="https://unpkg.com/face-api.js@0.22.2/dist/face-api.min.js"></script>
   <script>
+    const originalConsoleLog = console.log.bind(console);
+    function userLog(...args) {
+      originalConsoleLog(...args);
+      let logOutput = document.getElementById('logOutput');
+      if (!logOutput) {
+        logOutput = document.createElement('div');
+        logOutput.id = 'logOutput';
+        document.body.appendChild(logOutput);
+      }
+      const entry = document.createElement('div');
+      entry.textContent = args.join(' ');
+      logOutput.appendChild(entry);
+      while (logOutput.children.length > 100) {
+        logOutput.removeChild(logOutput.firstChild);
+      }
+      logOutput.scrollTop = logOutput.scrollHeight;
+    }
+    console.log = userLog;
+
     const moods = [
       { mood: 'Feliz', emoji: '😄', color: '#fffae6' },
       { mood: 'Triste', emoji: '😢', color: '#cce3f0' },


### PR DESCRIPTION
## Summary
- create `userLog` function to replace the default console.log and store messages on page
- auto-create `#logOutput` container when needed and keep last 100 entries
- style the log output div and pin it to the bottom of the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845f32b3a608331830361238d05aa37