### PR TITLE
Add Flask MP3 transcription demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Para adicionar ou editar humores ou alterar o mapeamento das expressões faciais
 
 Este projeto está licenciado sob os termos da [MIT License](LICENSE).
 
+
+## Transcrição de Áudio
+
+Este projeto também inclui um pequeno servidor Flask para transcrever arquivos MP3 usando o whisper local.
+
+### Executando
+
+1. Instale o Flask e o openai-whisper (ex.: `pip install flask openai-whisper`).
+2. Execute `python app.py` na pasta do projeto.
+3. Acesse `http://localhost:5000` em seu navegador e envie um arquivo MP3.
+4. A transcrição será exibida na tela após o processamento.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+from flask import Flask, render_template, request
+
+app = Flask(__name__)
+UPLOAD_FOLDER = 'uploads'
+
+# Garante que a pasta de uploads exista
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+@app.route('/')
+def index():
+    """Renderiza a página inicial com o formulário de upload."""
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    """Recebe o arquivo enviado, executa o whisper e exibe a transcrição."""
+    file = request.files.get('audio')
+    if not file:
+        return 'Nenhum arquivo enviado', 400
+
+    # Salva o arquivo enviado na pasta de uploads
+    filepath = os.path.join(UPLOAD_FOLDER, file.filename)
+    file.save(filepath)
+
+    # Comando para executar o whisper localmente
+    command = [
+        'whisper',
+        filepath,
+        '--model', 'medium',
+        '--language', 'pt'
+    ]
+    # Executa o whisper e aguarda finalizar
+    subprocess.run(command, check=True)
+
+    # O whisper gera um arquivo .txt com a transcrição
+    transcript_path = os.path.splitext(filepath)[0] + '.txt'
+
+    # Lê o conteúdo do arquivo de transcrição
+    with open(transcript_path, 'r', encoding='utf-8') as f:
+        transcription = f.read()
+
+    # Retorna o texto transcrito em uma página simples
+    return render_template('result.html', transcription=transcription)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Transcritor de Áudio</title>
+</head>
+<body>
+    <h1>Envie um arquivo MP3 para transcrição</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="audio" accept="audio/mpeg" required>
+        <button type="submit">Enviar</button>
+    </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Transcrição</title>
+</head>
+<body>
+    <h1>Resultado da Transcrição</h1>
+    <pre>{{ transcription }}</pre>
+    <a href="/">Voltar</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create simple Flask app using openai-whisper to transcribe MP3 uploads
- provide basic HTML pages for uploading a file and showing the result
- document usage of the new transcription feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e28d561c8331973879d0c8a608d9