### PR TITLE
Add face landmark model loading to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,7 @@
 
     Promise.all([
       faceapi.nets.tinyFaceDetector.loadFromUri(MODEL_URL),
+      faceapi.nets.faceLandmark68Net.loadFromUri(MODEL_URL),
       faceapi.nets.faceExpressionNet.loadFromUri(MODEL_URL),
     ]).then(startVideo);
 


### PR DESCRIPTION
## Summary
- load `faceLandmark68Net` model along with the other face-api models

## Testing
- `curl -I https://justadudewhohacks.github.io/face-api.js/models/face_landmark_68_model-weights_manifest.json` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684c3434e7408331910b0744753aa93e