### PR TITLE
Add error logging when loading face-api models

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,11 @@
       faceapi.nets.tinyFaceDetector.loadFromUri(MODEL_URL),
       faceapi.nets.faceLandmark68Net.loadFromUri(MODEL_URL),
       faceapi.nets.faceExpressionNet.loadFromUri(MODEL_URL),
-    ]).then(startVideo);
+    ])
+      .then(startVideo)
+      .catch((err) =>
+        console.error('Erro ao carregar modelos', err)
+      );
 
     function startVideo() {
       navigator.mediaDevices.getUserMedia({ video: true })


### PR DESCRIPTION
## Summary
- handle model load errors in `index.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c37c8480c8331949783409310a68c