### PR TITLE
Set canvas size when video loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,17 @@
       navigator.mediaDevices.getUserMedia({ video: true })
         .then((stream) => {
           video.srcObject = stream;
+          video.addEventListener('loadedmetadata', () => {
+            const overlay = document.getElementById('overlay');
+            const w = video.videoWidth;
+            const h = video.videoHeight;
+            video.width = w;
+            video.height = h;
+            overlay.width = w;
+            overlay.height = h;
+            overlay.style.width = `${w}px`;
+            overlay.style.height = `${h}px`;
+          });
         })
         .catch((err) => {
           alert('Não foi possível acessar a câmera. Verifique as permissões.');


### PR DESCRIPTION
## Summary
- size the video and overlay elements based on the real video dimensions
- keep face landmark detection working with `matchDimensions`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c3adf7f8c83318b1244a761dee1c4