### PR TITLE
Use Lucide info icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,11 @@
       font-size: 1.5em;
     }
 
+    #info-link svg {
+      width: 1em;
+      height: 1em;
+    }
+
     #emoji {
       font-size: 5em;
       transition: transform 0.3s ease;
@@ -108,7 +113,23 @@
   </style>
 </head>
 <body>
-  <a href="sobre.html" id="info-link" title="Sobre">&#8505;</a>
+  <a href="sobre.html" id="info-link" title="Sobre">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </svg>
+  </a>
   <h1>🎵 Moodify</h1>
   <div id="emojiList"></div>
   <div id="videoContainer">


### PR DESCRIPTION
## Summary
- replace info symbol with inline Lucide SVG
- style the new icon so it scales with text

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684d8992986c8331b95918a564d454a1