### PR TITLE
Fix return link overlap on about page

### DIFF
--- a/sobre.html
+++ b/sobre.html
@@ -18,13 +18,16 @@
       text-align: center;
       padding: 20px;
       position: relative;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
 
     header a.back {
       position: absolute;
       left: 20px;
-      top: 50%;
-      transform: translateY(-50%);
+      top: 20px;
+      transform: none;
       color: #fff;
       text-decoration: none;
       font-weight: bold;


### PR DESCRIPTION
## Summary
- tweak header layout on `sobre.html` so the back link doesn't overlap the text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d956bfd8c8331bd28d715fe57b4b0