### PR TITLE
Fix back link overlap

### DIFF
--- a/sobre.html
+++ b/sobre.html
@@ -26,8 +26,8 @@
     header a.back {
       position: absolute;
       left: 20px;
-      top: 20px;
-      transform: none;
+      top: 50%;
+      transform: translateY(-50%);
       color: #fff;
       text-decoration: none;
       font-weight: bold;


### PR DESCRIPTION
## Summary
- center the back link within the about page header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9723877883318cc853fbe0f488cb